### PR TITLE
emit the cropped image as a file as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ All inputs are optional. Either the `imageChangedEvent` or `imageBase64` should 
 | `imageQuality`          | number    | 92           | This only applies when using jpeg or webp as output format. Entering a number between 0 and 100 will determine the quality of the output image. |
 
 ### Outputs
-| Name              | Type   | Description |
-| ----------------- | ------ | ----------- |
-| `imageCropped`    | string | Emits a Base64 string of the cropped image each time it is cropped |
-| `imageLoaded`     | void   | Emits when the image was loaded into the cropper |
-| `loadImageFailed` | void   | Emits when a wrong file type was selected (only png, gif and jpg are allowed) |
+| Name                    | Type   | Description |
+| ----------------------- | ------ | ----------- |
+| `imageCroppedBase64`    | string | Emits a Base64 string of the cropped image each time it is cropped |
+| `imageCroppedFile`      | File   | Emits the cropped image as a file each time it is cropped |
+| `imageLoaded`           | void   | Emits when the image was loaded into the cropper |
+| `loadImageFailed`       | void   | Emits when a wrong file type was selected (only png, gif and jpg are allowed) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-image-cropper",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/image-cropper.component.ts
+++ b/src/image-cropper.component.ts
@@ -80,7 +80,8 @@ export class ImageCropperComponent implements OnChanges {
         y2: 10000
     };
 
-    @Output() imageCropped = new EventEmitter<string>();
+    @Output() imageCroppedBase64 = new EventEmitter<string>();
+    @Output() imageCroppedFile = new EventEmitter<File>();
     @Output() imageLoaded = new EventEmitter<void>();
     @Output() loadImageFailed = new EventEmitter<void>();
 
@@ -406,17 +407,24 @@ export class ImageCropperComponent implements OnChanges {
             const width = Math.round((this.cropper.x2 - this.cropper.x1) * ratio);
             const height = Math.round((this.cropper.y2 - this.cropper.y1) * ratio);
             const resizeRatio = this.getResizeRatio(width);
+
             const cropCanvas = document.createElement('canvas') as HTMLCanvasElement;
             cropCanvas.width = width * resizeRatio;
             cropCanvas.height = height * resizeRatio;
+
             const ctx = cropCanvas.getContext('2d');
             if (ctx) {
                 ctx.drawImage(this.originalImage, left, top, width, height, 0, 0, width * resizeRatio, height * resizeRatio);
                 const quality = Math.min(1, Math.max(0, this.imageQuality / 100));
-                const croppedImage = cropCanvas.toDataURL('image/' + this.format, quality);
+                const croppedImage = cropCanvas.toDataURL(`image/${this.format}`, quality);
                 if (croppedImage.length > 10) {
-                    this.imageCropped.emit(croppedImage);
+                    this.imageCroppedBase64.emit(croppedImage);
                 }
+                cropCanvas.toBlob(
+                    (fileImage: File) => this.imageCroppedFile.emit(fileImage),
+                    `image/${this.format}`,
+                    quality,
+                );
             }
         }
     }


### PR DESCRIPTION
Emit both types - base64 and file - of the cropped image.

### :warning: Breaking change
In this PR the output of the base64 is
`@Output() imageCroppedBase64 = new EventEmitter<string>();`
instead of
`@Output() imageCropped = new EventEmitter<string>();`
