### PR TITLE
Added missed line in index.ts for exporting ImageCroppedEvent

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export { ImageCropperModule } from './src/image-cropper.module';
 export { ImageCropperComponent } from './src/image-cropper.component';
+export { ImageCroppedEvent } from './src/image-cropper.component';


### PR DESCRIPTION
Trying to use this component from npm package I found that index.ts missing line for exporting ImageCroppedEvent. Line added, now npm package should be fully functional. 