### PR TITLE
preventDefault called to in startMove to suppress mobile scroll

### DIFF
--- a/src/component/image-cropper.component.ts
+++ b/src/component/image-cropper.component.ts
@@ -252,6 +252,7 @@ export class ImageCropperComponent implements OnChanges {
     }
 
     startMove(event: any, moveType: string, position: string | null = null): void {
+        event.preventDefault();
         this.moveStart = {
             active: true,
             type: moveType,


### PR DESCRIPTION
Without calling event.preventDefault, dragging the cropper around will also scroll the browser on mobile.