### PR TITLE
 Updating rotate and flip methods to return transformed base64 image in a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ To gain access to the image cropper's methods use `@ViewChild(ImageCropperCompon
 
 | Name                    | Returns           | Description |
 | ----------------------- | ----------------- | ----------- |
-| `rotateLeft`            | void              | Rotates the image to the left |
-| `rotateRight`           | void              | Rotates the image to the right |
-| `flipHorizontal`        | void              | Flips the image horizontally |
-| `flipVertical`          | void              | Flips the image vertically |
+| `rotateLeft`            | Promise&lt;string&gt; | Rotates the image to the left and returns a promise that resolves to the updated base64 image |
+| `rotateRight`           | Promise&lt;string&gt; | Rotates the image to the right and returns a promise that resolves to the updated base64 image |
+| `flipHorizontal`        | Promise&lt;string&gt; | Flips the image horizontally and returns a promise that resolves to the updated base64 image |
+| `flipVertical`          | Promise&lt;string&gt; | Flips the image vertically and returns a promise that resolves to the updated base64 image |
 | `crop`                  | ImageCroppedEvent (when `outputType` is `base64`) or Promise&lt;ImageCroppedEvent&gt; (when `outputType` is `file` or `both`)) | Crops the source image to the current cropper position. Accepts an output type as an argument, default is the one given in the `outputType` input (`base64`, `file` or `both`). Be sure to set `autoCrop` to `false` if you only wish to use this function directly. |
 
 ### Interfaces

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-image-cropper",
-  "version": "1.3.8",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-image-cropper",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "An image cropper for Angular",
   "main": "./bundles/ngx-image-cropper.umd.js",
   "module": "./ngx-image-cropper/ngx-image-cropper.es5.js",

--- a/src/component/image-cropper.component.ts
+++ b/src/component/image-cropper.component.ts
@@ -83,8 +83,8 @@ export class ImageCropperComponent implements OnChanges {
     @Output() loadImageFailed = new EventEmitter<void>();
 
     constructor(private sanitizer: DomSanitizer,
-        private cd: ChangeDetectorRef,
-        private zone: NgZone) {
+                private cd: ChangeDetectorRef,
+                private zone: NgZone) {
         this.initCropper();
     }
 
@@ -500,7 +500,7 @@ export class ImageCropperComponent implements OnChanges {
                     width,
                     height
                 );
-                const output = { width, height, imagePosition, cropperPosition: { ...this.cropper } };
+                const output = {width, height, imagePosition, cropperPosition: {...this.cropper}};
                 const resizeRatio = this.getResizeRatio(width);
                 if (resizeRatio !== 1) {
                     output.width = Math.floor(width * resizeRatio);


### PR DESCRIPTION
`rotateLeft`, `rotateRight`, `flipHorizontal`, and `flipVertical` have been
updated to return a promise, which when resolved provides the transformed image
as a base64 string. This is to account for situations where autoCrop is
disabled, but a user would like access to the transformed image immediately.

When autoCrop is disabled, there is a race condition that can occur if you
invoke `crop()` immediately after transforming the image. Instead of invoking
`crop()` to retrieve the updated base64 string, it is made available from the
return value of `rotateLeft` etc.