### PR TITLE
Cropper X's coordinates equal NaN

### DIFF
--- a/src/component/image-cropper.component.ts
+++ b/src/component/image-cropper.component.ts
@@ -599,7 +599,7 @@ export class ImageCropperComponent implements OnChanges {
     }
 
     private getClientX(event: any): number {
-        return event.clientX || event.touches && event.touches[0] && event.touches[0].clientX;
+        return event.touches && event.touches[0] && event.touches[0].clientX || event.clientX;
     }
 
     private getClientY(event: any): number {


### PR DESCRIPTION
Steps to reproduce: start dragging position of crop area and releases mouse button upon the left edge of browser (where mouse coordinate clientX = 0).

Expected behavior: left border of the cropper stick with left edge of image

What really happens: you get an error and component stops working until you update new image.

Description: cropper looks like `{x1: NaN, x2: NaN, ...}` after that mouse move. That's happened because `getClientX` function returns `undefined`. This function has inside:
`return event.clientX || event.touches && event.touches[0] && event.touches[0].clientX;`
which in case of moving mouse to x = 0 becomes: 
`return 0 || undefined` -> `undefined`.

Possible solution: eg reorder in return statement