### PR TITLE
Adding Keyboard Access (work in progress, please do not merge)

### DIFF
--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.html
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.html
@@ -5,6 +5,8 @@
         [src]="safeImgDataUrl"
         [style.visibility]="imageVisible ? 'visible' : 'hidden'"
         (load)="imageLoadedInView()"
+        tabindex='0'
+        (keydown)="keyboardAccess($event)"
     />
     <div class="cropper"
          *ngIf="imageVisible"


### PR DESCRIPTION
### What it does?

This PR is to add a keyboard accessibility to the image crop tool. User will be able to tab into the cropping tool and use keyboard to move, resize the cropper. Keys are following.

Move: Arrow buttons
Resize: Shift + Arrow buttons (arrow-up and arrow-right increase the size, and arrow-down and arrow-left decrease the size of the cropper)