### PR TITLE
refactor: remove dependecy on HttpClientModule and uses Image class to load the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ All inputs are optional. Either the `imageChangedEvent`, `imageBase64` or `image
 | `imageChangedEvent`        | FileEvent |              | The change event from your file input (set to `null` to reset the cropper) |
 | `imageFile`                | Blob(File)|              | The file you want to change (set to `null` to reset the cropper)           |
 | `imageBase64`              | string    |              | If you don't want to use a file input, you can set a base64 image directly and it will be loaded into the cropper |
-| `imageURL`                 | string    |              | If you don't want to use a file input or a base64 you can set an URL to get the image from. This feature requires `HttpClientModule` to be imported in your main app module so `HttpClient` instance can be injected into the component. If requesting an image from a different domain make sure Cross-Origin Resource Sharing (CORS) is allowed or the image will fail to load. |
+| `imageURL`                 | string    |              | If you don't want to use a file input or a base64 you can set an URL to get the image from. If requesting an image from a different domain make sure Cross-Origin Resource Sharing (CORS) is allowed or the image will fail to load. |
 | `format`                   | string    | png          | Output format (png, jpeg, webp, bmp, ico) (not all browsers support all types, png is always supported, others are optional) |
 | `aspectRatio`              | number    | 1 / 1        | The width / height ratio (e.g. 1 / 1 for a square, 4 / 3, 16 / 9 ...) |
 | `maintainAspectRatio`      | boolean   | true         | Keep width and height of cropped image equal according to the aspectRatio |

--- a/projects/demo-app/src/app/app.module.ts
+++ b/projects/demo-app/src/app/app.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
 import { ImageCropperModule } from 'ngx-image-cropper';
 
 import { AppComponent } from './app.component';
@@ -13,7 +12,6 @@ import { AppComponent } from './app.component';
     imports: [
         BrowserModule,
         FormsModule,
-        HttpClientModule,
         ReactiveFormsModule,
         ImageCropperModule
     ],

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -238,14 +238,21 @@ export class ImageCropperComponent implements OnChanges, OnInit {
     }
 
     private loadImageFromURL(url: string): void {
-        const load = (blob: Blob) => {
-            const reader = new FileReader();
-            reader.readAsDataURL(blob);
-            reader.onload = () => this.loadImage(reader.result as string, blob.type);
+        const img = new Image();
+        const error = _ => this.loadImageFailed.emit();
+        const load = _ => {
+            const canvas = document.createElement('canvas');
+            const context = canvas.getContext('2d');
+            canvas.width = img.width;
+            canvas.height = img.height;
+            context.drawImage(img, 0, 0);
+            this.checkExifAndLoadBase64Image(canvas.toDataURL());
         };
-        const error = () => this.loadImageFailed.emit();
 
-        this.http.get(url, { responseType: 'blob' }).toPromise().then(load).catch(error);
+        img.crossOrigin = 'anonymous';
+        img.onload = load;
+        img.onerror = error;
+        img.src = url;
     }
 
     private getTransformedSize(): Dimensions {


### PR DESCRIPTION
Refactor load image from URL to remove the dependency from `HttpClientModule` and use `Image` class to load the image. Uses HTML canvas to get the image base64 content.