### PR TITLE
Pinch to zoom not working

### DIFF
--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.html
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.html
@@ -1,5 +1,4 @@
 <div [style.background]="imageVisible && backgroundColor"
-     (pinchstart)="startPinch($event)"
      #wrapper
 >
     <img

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -378,6 +378,9 @@ export class ImageCropperComponent implements OnChanges, OnInit {
         if (this.Hammer) {
             const hammer = new this.Hammer(this.wrapper.nativeElement);
             hammer.get('pinch').set({enable: true});
+            hammer.on('pinchmove',this.onPinch.bind(this));
+            hammer.on('pinchend',this.pinchStop.bind(this));
+            hammer.on('pinchstart',this.startPinch.bind(this));
         } else if (isDevMode()) {
             console.warn('[NgxImageCropper] Could not find HammerJS - Pinch Gesture won\'t work');
         }
@@ -541,7 +544,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
         }
     }
 
-    @HostListener('document:pinchmove', ['$event'])
     onPinch(event: any) {
         if (this.moveStart.active) {
             if (event.stopPropagation) {
@@ -621,7 +623,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
         }
     }
 
-    @HostListener('document:pinchend')
     pinchStop(): void {
         if (this.moveStart.active) {
             this.moveStart.active = false;

--- a/projects/ngx-image-cropper/src/lib/utils/hammer.utils.ts
+++ b/projects/ngx-image-cropper/src/lib/utils/hammer.utils.ts
@@ -5,4 +5,6 @@ export interface HammerManager {
     get(eventName: string): HammerManager;
 
     set(options: any): HammerManager;
+
+    on(eventName: string, handler: (ev: any) => any);
 }


### PR DESCRIPTION
When using the library, pinch to zoom wasn't working. Upon looking into the code, the DOM events for Hammer.js aren't firing because domEvents is disabled in Hammer.js (this is the default behavior). Upon enabling domEvents with the debugger, this line:
`const scale = event.scale;`
in resize() needed to be changed to:
`const scale = event.gesture.scale`
however I figured that might break things in other places, so it would be better to use Hammer.js events. This pull request uses Hammer.js's `on` method to recieve events instead of using DOM events.