### PR TITLE
Added method to actually resize on keyboard actions

### DIFF
--- a/projects/demo-app/src/styles.scss
+++ b/projects/demo-app/src/styles.scss
@@ -1,1 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
+html, body {
+  overflow: hidden;
+}

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -334,11 +334,26 @@ export class ImageCropperComponent implements OnChanges, OnInit {
     const moveType = event.shiftKey ? MoveTypes.Resize : MoveTypes.Move;
     const position = event.altKey ? getInvertedPositionForKey(event.key) : getPositionForKey(event.key);
     const moveEvent = getEventForKey(event.key, this.settings.stepSize);
+    const bounds = moveType === MoveTypes.Resize ? this.getClientBoundsForKeyboardAction(position) : {clientX: 0, clientY: 0};
     event.preventDefault();
     event.stopPropagation();
-    this.startMove({clientX: 0, clientY: 0}, moveType, position);
+
+    this.startMove(bounds, moveType, position);
     this.moveImg(moveEvent);
     this.moveStop();
+  }
+
+  private getClientBoundsForKeyboardAction(position: string): any {
+    const clientBounds = { clientX: 0, clientY: 0};
+    const topSelector = document.querySelector('.ngx-ic-resize-bar.ngx-ic-top');
+    const bottomSelector = document.querySelector('.ngx-ic-resize-bar.ngx-ic-bottom');
+    clientBounds.clientY = bottomSelector?.getBoundingClientRect().y! - topSelector?.getBoundingClientRect().y!;
+
+    if (position === 'bottom') {
+      clientBounds.clientY = clientBounds.clientY * (1 / this.settings.stepSize);
+    }
+
+    return clientBounds;
   }
 
   startMove(event: any, moveType: MoveTypes, position: string | null = null): void {


### PR DESCRIPTION
Hi, I am using this library for a project but I came across this issue where I could not actually use the accessibility functionality with the keyboard actions like shift + arrowUp.
I tried this functionality locally with the demo app provided in the source, but that also did not actually resize the image.

@Mawi137  Could you have a look at this PR and tell me if it adds to the functionality of this library? Thanks a lot!

Edit: I also added overflow: hidden; to the global css of the demo-app as it allowed horizontal scrolling.