### PR TITLE
Ability to disable resetting crop on aspect ratio change

### DIFF
--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -59,6 +59,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   @Input() transform: ImageTransform = {};
   @Input() maintainAspectRatio = this.settings.maintainAspectRatio;
   @Input() aspectRatio = this.settings.aspectRatio;
+  @Input() resetCropOnAspectRatioChange = this.settings.resetCropOnAspectRatioChange;
   @Input() resizeToWidth = this.settings.resizeToWidth;
   @Input() resizeToHeight = this.settings.resizeToHeight;
   @Input() cropperMinWidth = this.settings.cropperMinWidth;
@@ -120,7 +121,11 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       this.setMaxSize();
       this.setCropperScaledMinSize();
       this.setCropperScaledMaxSize();
-      if (this.maintainAspectRatio && (changes['maintainAspectRatio'] || changes['aspectRatio'])) {
+      if (
+        this.maintainAspectRatio &&
+        (this.resetCropOnAspectRatioChange || !this.aspectRatioIsCorrect()) &&
+        (changes['maintainAspectRatio'] || changes['aspectRatio'])
+      ) {
         this.resetCropperPosition();
       } else if (changes['cropper']) {
         this.checkCropperPosition(false);
@@ -537,5 +542,10 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       return output;
     }
     return null;
+  }
+
+  private aspectRatioIsCorrect(): boolean {
+    const currentCropAspectRatio = (this.cropper.x2 - this.cropper.x1) / (this.cropper.y2 - this.cropper.y1);
+    return currentCropAspectRatio === this.aspectRatio;
   }
 }

--- a/projects/ngx-image-cropper/src/lib/interfaces/cropper-options.interface.ts
+++ b/projects/ngx-image-cropper/src/lib/interfaces/cropper-options.interface.ts
@@ -3,6 +3,7 @@ import { ImageTransform } from './image-transform.interface';
 export interface CropperOptions {
   format: OutputFormat;
   maintainAspectRatio: boolean;
+  resetCropOnAspectRatioChange: boolean;
   transform: ImageTransform;
   aspectRatio: number;
   resizeToWidth: number;

--- a/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
+++ b/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
@@ -9,6 +9,7 @@ export class CropperSettings {
   maintainAspectRatio = true;
   transform: ImageTransform = {};
   aspectRatio = 1;
+  resetCropOnAspectRatioChange = true;
   resizeToWidth = 0;
   resizeToHeight = 0;
   cropperMinWidth = 0;


### PR DESCRIPTION
It's not always desirable to reset the crop position when "maintainAspectRatio" is changed to true, for example if the aspect ratio is already correct and the crop is placed where the user wants it to be.

Happy to make improvements to this to get it into a state that makes sense from a full understanding of how the cropper should work - this was just the smallest change that worked for our use case.