### PR TITLE
Handle cropper position rounding issues

### DIFF
--- a/projects/ngx-image-cropper/src/lib/services/crop.service.spec.ts
+++ b/projects/ngx-image-cropper/src/lib/services/crop.service.spec.ts
@@ -1,3 +1,4 @@
+import { CropperPosition, Dimensions, LoadedImage } from '../interfaces';
 import { CropperSettings } from '../interfaces/cropper.settings';
 import { CropService } from './crop.service';
 
@@ -118,6 +119,87 @@ describe('CropService', () => {
         expect(service.getResizeRatio(250, 1000, settings)).toBe(0.5);
         expect(service.getResizeRatio(250, 50, settings)).toBe(1);
       });
+    });
+  });
+
+  describe("#getImagePosition", () => {
+    describe("when cropper position rounding shaves off a few pixels", () => {
+      const sourceImage = { nativeElement: { offsetWidth: 500 } };
+      const loadedImage = {
+        transformed: { size: { width: 1124, height: 750 } },
+      } as LoadedImage;
+      const cropper = { x1: 0, y1: 67.09608540925274, x2: 500, y2: 334 };
+      
+      it("should be moved back into bounds", () => {
+        settings.setOptions({ containWithinAspectRatio: false });
+        expect(
+          service.getImagePosition(sourceImage, loadedImage, cropper, settings)
+        ).toEqual({ x1: 0, y1: 150, x2: 1124, y2: 750 });
+      });
+    });
+  });
+
+  describe("#containWithinBounds", () => {
+    const maxDimensions: Dimensions = {
+      width: 600,
+      height: 400,
+    };
+    const cropperPositionBase: CropperPosition = {
+      x1: 100,
+      x2: 400,
+      y1: 250,
+      y2: 350,
+    };
+
+    it("when in bounds, should not change", () => {
+      const cropperPosition = { ...cropperPositionBase };
+      const expectedCropperPosition = { ...cropperPositionBase };
+      service.containWithinBounds(cropperPosition, maxDimensions);
+      expect(cropperPosition).toEqual(expectedCropperPosition);
+    });
+
+    it("when out of bounds left side, should be brought back in bounds", () => {
+      const cropperPosition = { ...cropperPositionBase, x1: -2 };
+      const expectedCropperPosition = {
+        ...cropperPositionBase,
+        x1: 0,
+        x2: 402,
+      };
+      service.containWithinBounds(cropperPosition, maxDimensions);
+      expect(cropperPosition).toEqual(expectedCropperPosition);
+    });
+
+    it("when out of bounds top side, should be brought back into bounds", () => {
+      const cropperPosition = { ...cropperPositionBase, y1: -3 };
+      const expectedCropperPosition = {
+        ...cropperPositionBase,
+        y1: 0,
+        y2: 353,
+      };
+      service.containWithinBounds(cropperPosition, maxDimensions);
+      expect(cropperPosition).toEqual(expectedCropperPosition);
+    });
+
+    it("when out of bounds right side, should be brought back into bounds", () => {
+      const cropperPosition = { ...cropperPositionBase, x2: 601 };
+      const expectedCropperPosition = {
+        ...cropperPositionBase,
+        x1: 99,
+        x2: 600,
+      };
+      service.containWithinBounds(cropperPosition, maxDimensions);
+      expect(cropperPosition).toEqual(expectedCropperPosition);
+    });
+
+    it("when out of bounds bottom side, should be brought back into bounds", () => {
+      const cropperPosition = { ...cropperPositionBase, y2: 405 };
+      const expectedCropperPosition = {
+        ...cropperPositionBase,
+        y1: 245,
+        y2: 400,
+      };
+      service.containWithinBounds(cropperPosition, maxDimensions);
+      expect(cropperPosition).toEqual(expectedCropperPosition);
     });
   });
 });


### PR DESCRIPTION
With very specific aspect ratios, the cropper position can be rounded out-of-bounds, the cropper will then end up being cropped to a smaller dimension than allowed by `cropperMinWidth` / `cropperMinHeight`.

The idea of this fix is to detect these edge-cases and instead of cropping the cropper, move it back into bounds while maintaining its size

I added tests but as a result both methods need to be defined as `public` :shrug: 

I don't know this project very well so there might be a better way to handle this, also there might be unintended side-effects that I'm not aware of.

This PR should close https://github.com/Mawi137/ngx-image-cropper/issues/561

Both examples below have `cropperMinHeight` set to `400`
### Before 
![ngx-cropper-solved-before](https://github.com/Mawi137/ngx-image-cropper/assets/76045417/02048fdc-c3d2-415c-8b60-bf296d1d833b)

### After
![ngx-cropper-solved-after](https://github.com/Mawi137/ngx-image-cropper/assets/76045417/31d76f37-c3e9-43b4-a80f-f881aba89a51)
