### PR TITLE
Example Usage in Readme.md small bug fixed to test it easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ export class YourComponent {
       this.croppedImage = this.sanitizer.bypassSecurityTrustUrl(event.objectUrl);
       // event.blob can be used to upload the cropped image
     }
-    imageLoaded(image: LoadedImage) {
+    imageLoaded(image?: LoadedImage) {
         // show cropper
     }
     cropperReady() {


### PR DESCRIPTION
It now works fine with updated line, just copy and paste it !

Otherwise it warns me with following error and not compiling with typescript.

```typescript
Expected 1 arguments, but got 0.ngtsc(2554)
home.page.ts(21, 33): Error occurs in the template of component EditPage.
(method) HomePage.imageLoaded(image: LoadedImage): void
```
