### PR TITLE
Improve app flow and reduce how often costly operations are called

### DIFF
--- a/projects/demo-app/src/app/app.component.html
+++ b/projects/demo-app/src/app/app.component.html
@@ -1,59 +1,85 @@
+<input [(ngModel)]="imageURL" placeholder="URL to load image" type="text" />
 <input type="file" (change)="fileChangeEvent($event)" accept="image/*" />
 <br />
 <br />
-<input [(ngModel)]="imageURL" placeholder="URL to load image" type="text" />
-<br />
-<br />
+<button (click)="toggleAspectRatio()">Aspect ratio: {{aspectRatio === 4/3 ? '4/3' : '16/5'}}</button>
+<button (click)="containWithinAspectRatio = !containWithinAspectRatio;">{{containWithinAspectRatio ? 'Fill Aspect Ratio' : 'Contain Within Aspect Ratio'}}</button>
 <button (click)="rotateLeft()">Rotate left</button>
 <button (click)="rotateRight()">Rotate right</button>
 <button (click)="flipHorizontal()">Flip horizontal</button>
 <button (click)="flipVertical()">Flip vertical</button>
 <br />
 <br />
-<button (click)="toggleContainWithinAspectRatio()">{{containWithinAspectRatio?'Fill Aspect Ratio':'Contain Within Aspect Ratio'}}</button>
-<button (click)="toggleAspectRatio()">Aspect ratio: {{aspectRatio === 4/3 ? '4/3' : '16/5'}}</button>
-<button (click)="resetImage()">Reset image</button>
+<section>
+  <button (click)="maintainAspectRatio = !maintainAspectRatio;">{{maintainAspectRatio ? "Don't Maintain Aspect Ratio" : 'Maintain Aspect Ratio'}}</button>
+  <label for="cropperStaticWidth">Cropper Static Width:</label>
+  <input id="cropperStaticWidth" type="number" (keyup)="debounce($event)" />
+  <label for="cropperMinWidth">Cropper Min Width:</label>
+  <input id="cropperMinWidth" type="number" (keyup)="debounce($event)"/>
+  <label for="cropperMaxWidth">Cropper Max Width:</label>
+  <input id="cropperMaxWidth" type="number" (keyup)="debounce($event)"/>
+  <span></span>
+  <label for="cropperStaticHeight">Cropper Static Height:</label>
+  <input id="cropperStaticHeight" type="number" (keyup)="debounce($event)" />
+  <label for="cropperMinHeight">Cropper Min Height:</label>
+  <input id="cropperMinHeight" type="number" (keyup)="debounce($event)"/>
+  <label for="cropperMaxHeight">Cropper Max Height:</label>
+  <input id="cropperMaxHeight" type="number" (keyup)="debounce($event)"/>
+</section>
 <br />
-<br />
-<input [(ngModel)]="rotation" placeholder="Rotation" type="number" (ngModelChange)="updateRotation()" /> <button (click)="zoomOut()">Zoom -</button> <button (click)="zoomIn()">Zoom +</button>
-<br />
-<br/>
+<input [(ngModel)]="rotation" placeholder="Rotation" type="number" (ngModelChange)="updateRotation()" /> 
+<button (click)="zoomOut()">Zoom -</button> 
+<button (click)="zoomIn()">Zoom +</button>
 <button (click)="moveLeft()">move left</button>
 <button (click)="moveRight()">move right</button>
-
-<button (click)="moveTop()">move top</button>
-<button (click)="moveBottom()">move bottom</button>
+<button (click)="moveUp()">move up</button>
+<button (click)="moveDown()">move down</button>
+<button (click)="allowMoveImage = !allowMoveImage;">{{allowMoveImage ? 'Disable' : 'Enable'}} image panning</button>
 <br/>
 <br/>
-<button (click)="allowMoveImage = !allowMoveImage;">{{allowMoveImage ? 'Disable' : 'Enable' }} image panning</button>
-<button (click)="hidden = !hidden;">{{hidden ? 'Show' : 'Hide' }}</button>
+<button (click)="hidden = !hidden;">{{hidden ? 'Show' : 'Hide'}}</button>
+<button (click)="disabled = !disabled;">{{disabled ? 'Enable' : 'Disable'}} Cropper</button>
+<button (click)="hideResizeSquares = !hideResizeSquares;">{{hideResizeSquares ? 'Show' : 'Hide'}} Resize Squares</button>
+<button (click)="resetCropOnAspectRatioChange = !resetCropOnAspectRatioChange;">{{resetCropOnAspectRatioChange ? "Don't" : ''}} Reset Crop On Aspect Ratio Change</button>
+<button (click)="toggleBackgroundColor()">Background Color: {{backgroundColor === 'red' ? 'blue' : 'red'}}</button>
+<button (click)="test()">Random test</button>
+<button (click)="resetImage()">Reset image</button>
+<br/>
 <br/>
 
-
-<div class="cropper-wrapper">
-  <image-cropper
+<div [style.display]="showCropper ? null : 'none'" class="cropper-wrapper">
+  <image-cropper 
     [imageChangedEvent]="imageChangedEvent"
     [imageURL]="imageURL"
-    [maintainAspectRatio]="true"
-    [containWithinAspectRatio]="containWithinAspectRatio"
-    [cropperMinWidth]="128"
-    [aspectRatio]="aspectRatio"
-    [onlyScaleDown]="true"
-    [roundCropper]="false"
-    [canvasRotation]="canvasRotation"
-    [(transform)]="transform"
-    [alignImage]="'center'"
-    [style.display]="showCropper ? null : 'none'"
-    [allowMoveImage]="allowMoveImage"
     [hidden]="hidden"
+    [disabled]="disabled"
+    [alignImage]="alignImage"
+    [roundCropper]="roundCropper"
+    [backgroundColor]="backgroundColor"
     imageAltText="Alternative image text"
-    backgroundColor="red"
+    [allowMoveImage]="allowMoveImage"
+    [hideResizeSquares]="hideResizeSquares"
+    [canvasRotation]="canvasRotation"
+    [aspectRatio]="aspectRatio"
+    [containWithinAspectRatio]="containWithinAspectRatio"
+    [maintainAspectRatio]="maintainAspectRatio"
+    [cropperStaticWidth]="cropperStaticWidth"
+    [cropperStaticHeight]="cropperStaticHeight"
+    [cropperMinWidth]="cropperMinWidth"
+    [cropperMinHeight]="cropperMinHeight"
+    [cropperMaxWidth]="cropperMaxWidth"
+    [cropperMaxHeight]="cropperMaxHeight"
+    [resetCropOnAspectRatioChange]="resetCropOnAspectRatioChange"
+    [cropper]="cropper"
+    [(transform)]="transform"
+    [onlyScaleDown]="true"
     output="blob"
     format="png"
     (imageCropped)="imageCropped($event)"
     (imageLoaded)="imageLoaded()"
     (cropperReady)="cropperReady($event)"
     (loadImageFailed)="loadImageFailed()"
+    (transformChange)="transformChange($event)"
   ></image-cropper>
   <div *ngIf="loading" class="loader">Loading...</div>
 </div>

--- a/projects/demo-app/src/app/app.component.html
+++ b/projects/demo-app/src/app/app.component.html
@@ -27,7 +27,7 @@
   <input id="cropperMaxHeight" type="number" (keyup)="debounce($event)"/>
 </section>
 <br />
-<input [(ngModel)]="rotation" placeholder="Rotation" type="number" (ngModelChange)="updateRotation()" /> 
+<input [(ngModel)]="transform.rotate" placeholder="Rotation" type="number" (ngModelChange)="updateRotation()" /> 
 <button (click)="zoomOut()">Zoom -</button> 
 <button (click)="zoomIn()">Zoom +</button>
 <button (click)="moveLeft()">move left</button>

--- a/projects/demo-app/src/app/app.component.scss
+++ b/projects/demo-app/src/app/app.component.scss
@@ -22,3 +22,39 @@ image-cropper {
   font-size: 20px;
   color: white;
 }
+
+input[type=number]{
+  width: 65px;
+}
+
+section {
+  border: 0;
+  display: grid;
+  justify-content: start;
+  align-items: center;
+  grid-template-columns: auto repeat(3, auto auto);
+  grid-template-rows: auto;
+  grid-gap: 0 5px;
+
+  label {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 14px;
+  }
+
+  input {
+    height: -webkit-fill-available;
+    margin-right: 5px;
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+  }
+  
+  button {
+    height: fit-content;
+    margin-right: 7px;
+  }
+}

--- a/projects/demo-app/src/app/app.component.ts
+++ b/projects/demo-app/src/app/app.component.ts
@@ -11,7 +11,6 @@ export class AppComponent {
   showCropper = false;
   loading = false;
   croppedImage: any = '';
-  rotation?: number;
 
   imageChangedEvent: any = '';
   imageURL?: string;
@@ -99,28 +98,28 @@ export class AppComponent {
   moveLeft() {
     this.transform = {
       ...this.transform,
-      translateH: this.transform.translateH! - 1
+      translateH: --this.transform.translateH!
     };
   }
 
   moveRight() {
     this.transform = {
       ...this.transform,
-      translateH: this.transform.translateH! + 1
+      translateH: ++this.transform.translateH! 
     };
   }
 
   moveDown() {
     this.transform = {
       ...this.transform,
-      translateV: this.transform.translateV! + 1
+      translateV: ++this.transform.translateV!
     };
   }
 
   moveUp() {
     this.transform = {
       ...this.transform,
-      translateV: this.transform.translateV! - 1
+      translateV: --this.transform.translateV!
     };
   }
 
@@ -156,6 +155,12 @@ export class AppComponent {
     this.maintainAspectRatio = false; 
     this.transform = {
       translateUnit: 'px',
+      scale: 1,
+      rotate: 0,
+      flipH: false,
+      flipV: false,
+      translateH: 0,
+      translateV: 0 // need to add everything or transform doesn't work after reset
     };
   }
 
@@ -176,7 +181,6 @@ export class AppComponent {
   updateRotation() {
     this.transform = {
       ...this.transform,
-      rotate: this.rotation
     };
   }
 

--- a/projects/demo-app/src/app/app.component.ts
+++ b/projects/demo-app/src/app/app.component.ts
@@ -160,7 +160,7 @@ export class AppComponent {
       flipH: false,
       flipV: false,
       translateH: 0,
-      translateV: 0 // need to add everything or transform doesn't work after reset
+      translateV: 0 
     };
   }
 
@@ -192,7 +192,7 @@ export class AppComponent {
     this.backgroundColor = this.backgroundColor === 'red' ? 'blue' : 'red';
   }
 
-  // to prevent over triggering app when typing
+  // prevent over triggering app when typing
   debounce(event: any) {
     clearTimeout(this.timeout);
     (this.eventList as any)[event.target!.id] = event.target.value;

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.html
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.html
@@ -42,7 +42,7 @@
       class="ngx-ic-move"
       role="presentation">
     </div>
-    <ng-container *ngIf="!hideResizeSquares">
+    <ng-container *ngIf="!hideResizeSquares && !(cropperStaticWidth && cropperStaticHeight)">
             <span class="ngx-ic-resize ngx-ic-topleft"
                   role="presentation"
                   (mousedown)="startMove($event, moveTypes.Resize, 'topleft')"

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.scss
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.scss
@@ -211,7 +211,7 @@
     }
   }
 
-  &.ngx-ix-hidden {
+  &.ngx-ic-hidden {
     display: none;
   }
 }

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -91,7 +91,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   @Input() alignImage: 'left' | 'center' = this.settings.alignImage;
   @HostBinding('class.disabled')
   @Input() disabled = false;
-  @HostBinding('class.ngx-ic-hidden') // fix typo
+  @HostBinding('class.ngx-ic-hidden')
   @Input() hidden = false;
 
   @Output() imageCropped = new EventEmitter<ImageCroppedEvent>();
@@ -117,22 +117,10 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   ngOnChanges(changes: SimpleChanges): void {  
     const oldCropper = { ...this.settings.cropper };
     const oldTransform = { ...this.settings.transform };
-
-    /*
-    if(changes['transform'] && changes['transform'].previousValue) {
-      console.log(
-        '\n changes previous value ', changes['transform'].previousValue.translateH, changes['transform'].previousValue.translateV,
-        '\n changes current value ', changes['transform'].currentValue.translateH, changes['transform'].currentValue.translateV,
-        '\n settings ', this.settings.transform.translateH, this.settings.transform.translateV,
-        '\n this ', this.transform.translateH, this.transform.translateV,
-        );
-    }
-    */
     
     this.settings.setOptionsFromChanges(changes);
     this.onChangesInputImage(changes); 
 
-    // changed to transformed.image cos everything else depends on it
     if (!this.loadedImage?.transformed.image.complete) return; 
  
     if ((this.containWithinAspectRatio && changes["aspectRatio"]) || changes["containWithinAspectRatio"] || changes["canvasRotation"]) { 
@@ -170,7 +158,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       //TODO(loiddy): decouple min, max and static sizes. app should be able to respond to changes individually too (also have only one static side) (fixed in future PR).
     }
 
-    // if cropper was emitted I'd check for isNewPosition here
     if (changes["cropper"]) checkCropperWithinBounds = true;
 
     if (checkCropperWithinBounds) {
@@ -180,8 +167,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
     }
 
     if (changes["transform"]) {
-      // delete cos initialised from settings like the rest
-      // this.transform = this.transform || {}; 
       if (this.imagePositionIsNewTransform(oldTransform, this.transform)) {
         this.setCssTransform();
         crop = true;
@@ -200,31 +185,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       });
     }
   }
-
-  /* TODO: DELETE this method 
-
-  Only this.hideResizeSquares = true; is used, but it remains as true until parent sets it to false – if they were to change both static sides, this would still be true. The rest isn't used cos cropperSCALEDMin and Max are used in the cropperPosition service and here local versions are used to calculate the scaled versions. 
-
-  I'm adding an if condition to the html and a blocker to onPinch – handleMouseMove has one but onPinch doesn't – to achieve what I suspect this was trying to do. 
-
-  Deleting settings.setOptions from settings too as it's only used here.
-
-  private onChangesUpdateSettings(changes: SimpleChanges) {
-    this.settings.setOptionsFromChanges(changes);
-
-    if (this.settings.cropperStaticHeight && this.settings.cropperStaticWidth) {
-      this.hideResizeSquares = true;
-      this.settings.setOptions({
-        hideResizeSquares: true,
-        cropperMinWidth: this.settings.cropperStaticWidth,
-        cropperMinHeight: this.settings.cropperStaticHeight,
-        cropperMaxHeight: this.settings.cropperStaticHeight,
-        cropperMaxWidth: this.settings.cropperStaticWidth,
-        maintainAspectRatio: false
-      });
-    }
-  }
-  */
 
   private onChangesInputImage(changes: SimpleChanges): void {
     if (changes['imageChangedEvent'] || changes['imageURL'] || changes['imageBase64'] || changes['imageFile']) {
@@ -249,7 +209,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   }
 
   private setCssTransform() {
-    console.log('SET CSS')
     const translateUnit = this.transform?.translateUnit || '%';
     this.safeTransformStyle = this.sanitizer.bypassSecurityTrustStyle(
       `translate(${this.transform.translateH || 0}${translateUnit}, ${this.transform.translateV || 0}${translateUnit})` +
@@ -332,12 +291,11 @@ export class ImageCropperComponent implements OnChanges, OnInit {
     if (this.setImageMaxSizeRetries > 40) {
       this.loadImageFailed.emit();
     } else if (this.sourceImageLoaded()) {
-      console.log('CHECK IMAGE MAX SIZE RECURSIVELY')
       this.setMaxSize();
       this.setCropperScaledMinSize();
       this.setCropperScaledMaxSize();
       this.checkCropperWithinCropperSizeBounds(true);
-      //TODO(loiddy): add checkCropperWithinMaxSizeBounds when resetCropper and x2=0 is fully implemented. Explained in cropper position service.
+      //TODO(loiddy): add checkCropperWithinMaxSizeBounds when resetCropper and x2=0 is fully implemented. 
       this.setCssTransform();
       this.imageVisible = true;
       this.doAutoCrop();
@@ -366,7 +324,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       this.resizeCropperPosition(oldMaxSize);
       this.setCropperScaledMinSize();
       this.setCropperScaledMaxSize();
-      this.cd.markForCheck(); // when triggered from ngOnChanges we need to let angular know to paint cropper
+      this.cd.markForCheck(); 
     }
   }
 
@@ -471,7 +429,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   }
 
   startPinch(event: any) {
-    // safeImgDataUrl can be a dummy if reset(), below also covers if hidden
     if (this.disabled || !this.sourceImageLoaded()) { 
       return;
     }
@@ -537,7 +494,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
 
   private setMaxSize(): void {
     if (this.sourceImage) {
-      console.log('SET MAX SIZE');
       const sourceImageStyle = getComputedStyle(this.sourceImage.nativeElement);
       this.maxSize.width = parseFloat(sourceImageStyle.width);
       this.maxSize.height = parseFloat(sourceImageStyle.height);
@@ -556,7 +512,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   }
 
   private setCropperScaledMinWidth(): void {
-    console.log('SET CROPPER MIN WIDTH')
     this.settings.cropperScaledMinWidth = this.cropperMinWidth > 0
       ? Math.max(20, this.cropperMinWidth / this.loadedImage!.transformed.image.width * this.maxSize.width)
       : 20;
@@ -564,28 +519,23 @@ export class ImageCropperComponent implements OnChanges, OnInit {
 
   private setCropperScaledMinHeight(): void {
     if (this.maintainAspectRatio) {
-      console.log('SET CROPPER MIN HEIGHT mantain aspect ratio')
       this.settings.cropperScaledMinHeight = Math.max(20, this.settings.cropperScaledMinWidth / this.aspectRatio);
     } else if (this.cropperMinHeight > 0) {
-      console.log('SET CROPPER MIN HEIGHT')
       this.settings.cropperScaledMinHeight = Math.max(
         20,
         this.cropperMinHeight / this.loadedImage!.transformed.image.height * this.maxSize.height
       );
     } else {
-      console.log('SET CROPPER MIN HEIGHT fallback')
       this.settings.cropperScaledMinHeight = 20;
     }
   }
 
   private setCropperScaledMaxSize(): void {
     if (this.loadedImage?.transformed?.image) {
-      console.log('SET CROPPER MAX WIDTH AND HEIGHT')
       const ratio = this.loadedImage.transformed.size.width / this.maxSize.width;
       this.settings.cropperScaledMaxWidth = this.cropperMaxWidth > 20 ? this.cropperMaxWidth / ratio : this.maxSize.width;
       this.settings.cropperScaledMaxHeight = this.cropperMaxHeight > 20 ? this.cropperMaxHeight / ratio : this.maxSize.height;
       if (this.maintainAspectRatio) {
-        console.log('SET CROPPER MAX WIDTH AND HEIGHT mantain aspect ratio')
         if (this.settings.cropperScaledMaxWidth > this.settings.cropperScaledMaxHeight * this.aspectRatio) {
           this.settings.cropperScaledMaxWidth = this.settings.cropperScaledMaxHeight * this.aspectRatio;
         } else if (this.settings.cropperScaledMaxWidth < this.settings.cropperScaledMaxHeight * this.aspectRatio) {
@@ -593,14 +543,12 @@ export class ImageCropperComponent implements OnChanges, OnInit {
         }
       }
     } else {
-      console.log('SET CROPPER MAX WIDTH AND HEIGHT fallback')
       this.settings.cropperScaledMaxWidth = this.maxSize.width;
       this.settings.cropperScaledMaxHeight = this.maxSize.height;
     }
   }
 
   private checkCropperWithinMaxSizeBounds(maintainSize = false): void {
-    console.log('CHECK CROPPER WITHIN MAX SIZE BOUNDS')
     if (this.cropper.x1 < 0) {
       this.cropper.x2 -= maintainSize ? this.cropper.x1 : 0;
       this.cropper.x1 = 0;
@@ -643,7 +591,6 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   }
 
   // TODO:(loiddy) move to image pos serivice when added.
-  // Useful to check if to send transformChanged event. Will be used more later on.
   private imagePositionIsNewPosition(oldTransform: ImageTransform, newTransform: ImageTransform){
     if ((oldTransform.translateH ?? 0) !== (newTransform.translateH ?? 0)) return true;
     if ((oldTransform.translateV ?? 0) !== (newTransform.translateV ?? 0)) return true;

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -135,7 +135,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       ) {
         this.checkCropperWithinCropperSizeBounds(true);
       } else if (changes['cropper']) {
-        this.checkCropperPosition(false);
+        this.checkCropperWithinMaxSizeBounds(false);
         this.doAutoCrop();
       }
     }
@@ -436,12 +436,12 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       }
       if (this.moveStart!.type === MoveTypes.Move) {
         this.cropperPositionService.move(event, this.moveStart!, this.cropper);
-        this.checkCropperPosition(true);
+        this.checkCropperWithinMaxSizeBounds(true);
       } else if (this.moveStart!.type === MoveTypes.Resize) {
         if (!this.cropperStaticWidth && !this.cropperStaticHeight) {
           this.cropperPositionService.resize(event, this.moveStart!, this.cropper, this.maxSize, this.settings);
         }
-        this.checkCropperPosition(false);
+        this.checkCropperWithinMaxSizeBounds(false);
       } else if (this.moveStart!.type === MoveTypes.Drag) {
         const diffX = this.cropperPositionService.getClientX(event) - this.moveStart!.clientX;
         const diffY = this.cropperPositionService.getClientY(event) - this.moveStart!.clientY;
@@ -465,7 +465,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       }
       if (this.moveStart!.type === MoveTypes.Pinch) {
         this.cropperPositionService.resize(event, this.moveStart!, this.cropper, this.maxSize, this.settings);
-        this.checkCropperPosition(false);
+        this.checkCropperWithinMaxSizeBounds(false);
       }
       this.cd.markForCheck();
     }
@@ -535,8 +535,8 @@ export class ImageCropperComponent implements OnChanges, OnInit {
     }
   }
 
-  private checkCropperPosition(maintainSize = false): void {
-    console.log('CHECK CROPPER POSITION')
+  private checkCropperWithinMaxSizeBounds(maintainSize = false): void {
+    console.log('CHECK CROPPER WITHIN MAX SIZE BOUNDS')
     if (this.cropper.x1 < 0) {
       this.cropper.x2 -= maintainSize ? this.cropper.x1 : 0;
       this.cropper.x1 = 0;

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -86,12 +86,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   @Input() containWithinAspectRatio = this.settings.containWithinAspectRatio;
   @Input() hideResizeSquares = this.settings.hideResizeSquares;
   @Input() allowMoveImage = false;
-  @Input() cropper: CropperPosition = {
-    x1: -100,
-    y1: -100,
-    x2: 10000,
-    y2: 10000
-  };
+  @Input() cropper: CropperPosition = {x1: 0, y1: 0, x2: 0, y2: 0};
   @HostBinding('style.text-align')
   @Input() alignImage: 'left' | 'center' = this.settings.alignImage;
   @HostBinding('class.disabled')
@@ -138,7 +133,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
         (this.resetCropOnAspectRatioChange || !this.aspectRatioIsCorrect()) &&
         (changes['maintainAspectRatio'] || changes['aspectRatio'])
       ) {
-        this.resetCropperPosition();
+        this.checkCropperWithinCropperSizeBounds(true);
       } else if (changes['cropper']) {
         this.checkCropperPosition(false);
         this.doAutoCrop();
@@ -221,10 +216,10 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       width: 0,
       height: 0
     };
-    this.cropper.x1 = -100;
-    this.cropper.y1 = -100;
-    this.cropper.x2 = 10000;
-    this.cropper.y2 = 10000;
+    this.cropper.x1 = 0;
+    this.cropper.y1 = 0;
+    this.cropper.x2 = 0;
+    this.cropper.y2 = 0;
     this.moveStart = {
       active: false,
       type: null,
@@ -283,7 +278,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
       this.setMaxSize();
       this.setCropperScaledMinSize();
       this.setCropperScaledMaxSize();
-      this.resetCropperPosition();
+      this.checkCropperWithinCropperSizeBounds(true);
       this.cropperReady.emit({...this.maxSize});
       this.cd.markForCheck();
     } else {
@@ -338,8 +333,8 @@ export class ImageCropperComponent implements OnChanges, OnInit {
     }
   }
 
-  resetCropperPosition(): void {
-    this.cropperPositionService.resetCropperPosition(this.sourceImage, this.cropper, this.settings, this.maxSize);
+  checkCropperWithinCropperSizeBounds(resetCropper: boolean): void {
+    this.cropperPositionService.checkWithinCropperSizeBounds(this.cropper, this.settings, this.maxSize, resetCropper);
     this.doAutoCrop();
     this.imageVisible = true;
   }

--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -196,6 +196,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   }
 
   private setCssTransform() {
+    console.log('SET CSS')
     const translateUnit = this.transform?.translateUnit || '%';
     this.safeTransformStyle = this.sanitizer.bypassSecurityTrustStyle(
       `translate(${this.transform.translateH || 0}${translateUnit}, ${this.transform.translateV || 0}${translateUnit})` +
@@ -281,6 +282,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
     if (this.setImageMaxSizeRetries > 40) {
       this.loadImageFailed.emit();
     } else if (this.sourceImageLoaded()) {
+      console.log('CHECK IMAGE MAX SIZE RECURSIVELY')
       this.setMaxSize();
       this.setCropperScaledMinSize();
       this.setCropperScaledMaxSize();
@@ -479,6 +481,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
 
   private setMaxSize(): void {
     if (this.sourceImage) {
+      console.log('SET MAX SIZE');
       const sourceImageStyle = getComputedStyle(this.sourceImage.nativeElement);
       this.maxSize.width = parseFloat(sourceImageStyle.width);
       this.maxSize.height = parseFloat(sourceImageStyle.height);
@@ -497,6 +500,7 @@ export class ImageCropperComponent implements OnChanges, OnInit {
   }
 
   private setCropperScaledMinWidth(): void {
+    console.log('SET CROPPER MIN WIDTH')
     this.settings.cropperScaledMinWidth = this.cropperMinWidth > 0
       ? Math.max(20, this.cropperMinWidth / this.loadedImage!.transformed.image.width * this.maxSize.width)
       : 20;
@@ -504,23 +508,28 @@ export class ImageCropperComponent implements OnChanges, OnInit {
 
   private setCropperScaledMinHeight(): void {
     if (this.maintainAspectRatio) {
+      console.log('SET CROPPER MIN HEIGHT mantain aspect ratio')
       this.settings.cropperScaledMinHeight = Math.max(20, this.settings.cropperScaledMinWidth / this.aspectRatio);
     } else if (this.cropperMinHeight > 0) {
+      console.log('SET CROPPER MIN HEIGHT')
       this.settings.cropperScaledMinHeight = Math.max(
         20,
         this.cropperMinHeight / this.loadedImage!.transformed.image.height * this.maxSize.height
       );
     } else {
+      console.log('SET CROPPER MIN HEIGHT fallback')
       this.settings.cropperScaledMinHeight = 20;
     }
   }
 
   private setCropperScaledMaxSize(): void {
     if (this.loadedImage?.transformed?.image) {
+      console.log('SET CROPPER MAX WIDTH AND HEIGHT')
       const ratio = this.loadedImage.transformed.size.width / this.maxSize.width;
       this.settings.cropperScaledMaxWidth = this.cropperMaxWidth > 20 ? this.cropperMaxWidth / ratio : this.maxSize.width;
       this.settings.cropperScaledMaxHeight = this.cropperMaxHeight > 20 ? this.cropperMaxHeight / ratio : this.maxSize.height;
       if (this.maintainAspectRatio) {
+        console.log('SET CROPPER MAX WIDTH AND HEIGHT mantain aspect ratio')
         if (this.settings.cropperScaledMaxWidth > this.settings.cropperScaledMaxHeight * this.aspectRatio) {
           this.settings.cropperScaledMaxWidth = this.settings.cropperScaledMaxHeight * this.aspectRatio;
         } else if (this.settings.cropperScaledMaxWidth < this.settings.cropperScaledMaxHeight * this.aspectRatio) {
@@ -528,12 +537,14 @@ export class ImageCropperComponent implements OnChanges, OnInit {
         }
       }
     } else {
+      console.log('SET CROPPER MAX WIDTH AND HEIGHT fallback')
       this.settings.cropperScaledMaxWidth = this.maxSize.width;
       this.settings.cropperScaledMaxHeight = this.maxSize.height;
     }
   }
 
   private checkCropperPosition(maintainSize = false): void {
+    console.log('CHECK CROPPER POSITION')
     if (this.cropper.x1 < 0) {
       this.cropper.x2 -= maintainSize ? this.cropper.x1 : 0;
       this.cropper.x1 = 0;

--- a/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
+++ b/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
@@ -39,17 +39,14 @@ export class CropperSettings {
   cropperScaledMaxHeight = 20;
   stepSize = this.initialStepSize;
 
-  setOptions(options: Partial<CropperOptions>): void {
-    Object.keys(options)
-      .filter((k) => k in this)
-      .forEach((k) => (this as any)[k] = (options as any)[k]);
-    this.validateOptions();
-  }
-
   setOptionsFromChanges(changes: SimpleChanges): void {
-    Object.keys(changes)
-      .filter((k) => k in this)
-      .forEach((k) => (this as any)[k] = changes[k].currentValue);
+    /*
+    Better to clone the objects so the properties don't share memory pointer. things like, for example, setting transform in parent like transform = {...transform, translateH: ++translateH} don't break the app this way (I've added this to the demo)
+    */
+    for(const k in changes){
+      if (k === 'transform' || k === 'cropper') (this as any)[k] = { ...changes[k].currentValue };
+      else if (k in this) (this as any)[k] = changes[k].currentValue;
+    }
     this.validateOptions();
   }
 

--- a/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
+++ b/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
@@ -40,9 +40,6 @@ export class CropperSettings {
   stepSize = this.initialStepSize;
 
   setOptionsFromChanges(changes: SimpleChanges): void {
-    /*
-    Better to clone the objects so the properties don't share memory pointer. things like, for example, setting transform in parent like transform = {...transform, translateH: ++translateH} don't break the app this way (I've added this to the demo)
-    */
     for(const k in changes){
       if (k === 'transform' || k === 'cropper') (this as any)[k] = { ...changes[k].currentValue };
       else if (k in this) (this as any)[k] = changes[k].currentValue;

--- a/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
+++ b/projects/ngx-image-cropper/src/lib/interfaces/cropper.settings.ts
@@ -1,5 +1,5 @@
 import { CropperOptions, OutputFormat, OutputType } from './cropper-options.interface';
-import { ImageTransform } from './image-transform.interface';
+import { ImageTransform, CropperPosition } from './';
 import { SimpleChanges } from '@angular/core';
 
 export class CropperSettings {
@@ -13,6 +13,7 @@ export class CropperSettings {
   resetCropOnAspectRatioChange = true;
   resizeToWidth = 0;
   resizeToHeight = 0;
+  cropper: CropperPosition = {x1: 0, y1: 0, x2: 0, y2: 0};
   cropperMinWidth = 0;
   cropperMinHeight = 0;
   cropperMaxHeight = 0;

--- a/projects/ngx-image-cropper/src/lib/interfaces/move-start.interface.ts
+++ b/projects/ngx-image-cropper/src/lib/interfaces/move-start.interface.ts
@@ -1,14 +1,11 @@
-import { ImageTransform } from './image-transform.interface';
+import { CropperPosition, ImageTransform } from './';
 
 export interface MoveStart {
   active: boolean;
   type: MoveTypes | null;
   position: string | null;
   transform?: ImageTransform;
-  x1: number;
-  y1: number;
-  x2: number;
-  y2: number;
+  cropper: CropperPosition;
   clientX: number;
   clientY: number;
 }

--- a/projects/ngx-image-cropper/src/lib/services/crop.service.spec.ts
+++ b/projects/ngx-image-cropper/src/lib/services/crop.service.spec.ts
@@ -1,10 +1,18 @@
-import { CropperSettings } from '../interfaces/cropper.settings';
+import { SimpleChange, SimpleChanges } from '@angular/core';
+import { CropperSettings,CropperOptions } from '../interfaces/';
 import { CropService } from './crop.service';
 
 describe('CropService', () => {
 
   let service: CropService;
   let settings: CropperSettings;
+  const setOptions = (options: Partial<CropperOptions>) => {
+    let dummyChanges: SimpleChanges = {};
+    for(let key in options) {
+      (dummyChanges as any)[key] = new SimpleChange(undefined, (options as any)[key], true);
+    }
+    settings.setOptionsFromChanges(dummyChanges);
+  }
 
   beforeEach(() => {
     service = new CropService();
@@ -16,7 +24,7 @@ describe('CropService', () => {
     describe('when onlyScaleDown is false', () => {
 
       it('when resizeToWidth is set', () => {
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 500,
           resizeToHeight: 0,
           onlyScaleDown: false
@@ -28,10 +36,10 @@ describe('CropService', () => {
         expect(service.getResizeRatio(250, 1234, settings)).toBe(2);
       });
       it('when resizeToHeight is set', () => {
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 0,
           resizeToHeight: 500,
-          onlyScaleDown: false
+          onlyScaleDown: false,
         });
 
         expect(service.getResizeRatio(123, 1000, settings)).toBe(0.5);
@@ -40,7 +48,7 @@ describe('CropService', () => {
         expect(service.getResizeRatio(1234, 250, settings)).toBe(2);
       });
       it('when resizeToWidth and resizeToHeight is set', () => {
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 500,
           resizeToHeight: 500,
           onlyScaleDown: false
@@ -51,7 +59,7 @@ describe('CropService', () => {
         expect(service.getResizeRatio(125, 250, settings)).toBe(2);
 
 
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 1000,
           resizeToHeight: 500,
           onlyScaleDown: false
@@ -64,7 +72,7 @@ describe('CropService', () => {
         expect(service.getResizeRatio(500, 123, settings)).toBe(2);
 
 
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 500,
           resizeToHeight: 1000,
           onlyScaleDown: false
@@ -81,7 +89,7 @@ describe('CropService', () => {
     describe('when onlyScaleDown is true', () => {
 
       it('when resizeToWidth is set', () => {
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 500,
           resizeToHeight: 0,
           onlyScaleDown: true
@@ -93,7 +101,7 @@ describe('CropService', () => {
 
 
       it('when resizeToHeight is set', () => {
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 0,
           resizeToHeight: 500,
           onlyScaleDown: true
@@ -105,7 +113,7 @@ describe('CropService', () => {
 
 
       it('when resizeToWidth and resizeToHeight is set', () => {
-        settings.setOptions({
+        setOptions({
           resizeToWidth: 1000,
           resizeToHeight: 500,
           onlyScaleDown: true

--- a/projects/ngx-image-cropper/src/lib/services/cropper-position.service.ts
+++ b/projects/ngx-image-cropper/src/lib/services/cropper-position.service.ts
@@ -9,6 +9,7 @@ export class CropperPositionService {
     if (!sourceImage?.nativeElement) {
       return;
     }
+    console.log('RESET CROPPER POSITION')
     if (settings.cropperStaticHeight && settings.cropperStaticWidth) {
       cropperPosition.x1 = 0;
       cropperPosition.x2 = maxSize.width > settings.cropperStaticWidth ?
@@ -41,6 +42,7 @@ export class CropperPositionService {
   }
 
   move(event: any, moveStart: MoveStart, cropperPosition: CropperPosition) {
+    console.log('MOVE')
     const diffX = this.getClientX(event) - moveStart.clientX;
     const diffY = this.getClientY(event) - moveStart.clientY;
 
@@ -51,6 +53,7 @@ export class CropperPositionService {
   }
 
   resize(event: any, moveStart: MoveStart, cropperPosition: CropperPosition, maxSize: Dimensions, settings: CropperSettings): void {
+    console.log('RESIZE')
     const moveX = this.getClientX(event) - moveStart.clientX;
     const moveY = this.getClientY(event) - moveStart.clientY;
     switch (moveStart.position) {
@@ -129,6 +132,7 @@ export class CropperPositionService {
   }
 
   checkAspectRatio(position: string, cropperPosition: CropperPosition, maxSize: Dimensions, settings: CropperSettings): void {
+    console.log(' - CHECK ASPECT RATIO')
     let overflowX = 0;
     let overflowY = 0;
 

--- a/projects/ngx-image-cropper/src/lib/services/cropper-position.service.ts
+++ b/projects/ngx-image-cropper/src/lib/services/cropper-position.service.ts
@@ -46,10 +46,10 @@ export class CropperPositionService {
     const diffX = this.getClientX(event) - moveStart.clientX;
     const diffY = this.getClientY(event) - moveStart.clientY;
 
-    cropperPosition.x1 = moveStart.x1 + diffX;
-    cropperPosition.y1 = moveStart.y1 + diffY;
-    cropperPosition.x2 = moveStart.x2 + diffX;
-    cropperPosition.y2 = moveStart.y2 + diffY;
+    cropperPosition.x1 = moveStart.cropper.x1 + diffX;
+    cropperPosition.y1 = moveStart.cropper.y1 + diffY;
+    cropperPosition.x2 = moveStart.cropper.x2 + diffX;
+    cropperPosition.y2 = moveStart.cropper.y2 + diffY;
   }
 
   resize(event: any, moveStart: MoveStart, cropperPosition: CropperPosition, maxSize: Dimensions, settings: CropperSettings): void {
@@ -58,52 +58,52 @@ export class CropperPositionService {
     const moveY = this.getClientY(event) - moveStart.clientY;
     switch (moveStart.position) {
       case 'left':
-        cropperPosition.x1 = Math.min(Math.max(moveStart.x1 + moveX, cropperPosition.x2 - settings.cropperScaledMaxWidth),
+        cropperPosition.x1 = Math.min(Math.max(moveStart.cropper.x1 + moveX, cropperPosition.x2 - settings.cropperScaledMaxWidth),
           cropperPosition.x2 - settings.cropperScaledMinWidth);
         break;
       case 'topleft':
-        cropperPosition.x1 = Math.min(Math.max(moveStart.x1 + moveX, cropperPosition.x2 - settings.cropperScaledMaxWidth),
+        cropperPosition.x1 = Math.min(Math.max(moveStart.cropper.x1 + moveX, cropperPosition.x2 - settings.cropperScaledMaxWidth),
           cropperPosition.x2 - settings.cropperScaledMinWidth);
-        cropperPosition.y1 = Math.min(Math.max(moveStart.y1 + moveY, cropperPosition.y2 - settings.cropperScaledMaxHeight),
+        cropperPosition.y1 = Math.min(Math.max(moveStart.cropper.y1 + moveY, cropperPosition.y2 - settings.cropperScaledMaxHeight),
           cropperPosition.y2 - settings.cropperScaledMinHeight);
         break;
       case 'top':
-        cropperPosition.y1 = Math.min(Math.max(moveStart.y1 + moveY, cropperPosition.y2 - settings.cropperScaledMaxHeight),
+        cropperPosition.y1 = Math.min(Math.max(moveStart.cropper.y1 + moveY, cropperPosition.y2 - settings.cropperScaledMaxHeight),
           cropperPosition.y2 - settings.cropperScaledMinHeight);
         break;
       case 'topright':
-        cropperPosition.x2 = Math.max(Math.min(moveStart.x2 + moveX, cropperPosition.x1 + settings.cropperScaledMaxWidth),
+        cropperPosition.x2 = Math.max(Math.min(moveStart.cropper.x2 + moveX, cropperPosition.x1 + settings.cropperScaledMaxWidth),
           cropperPosition.x1 + settings.cropperScaledMinWidth);
-        cropperPosition.y1 = Math.min(Math.max(moveStart.y1 + moveY, cropperPosition.y2 - settings.cropperScaledMaxHeight),
+        cropperPosition.y1 = Math.min(Math.max(moveStart.cropper.y1 + moveY, cropperPosition.y2 - settings.cropperScaledMaxHeight),
           cropperPosition.y2 - settings.cropperScaledMinHeight);
         break;
       case 'right':
-        cropperPosition.x2 = Math.max(Math.min(moveStart.x2 + moveX, cropperPosition.x1 + settings.cropperScaledMaxWidth),
+        cropperPosition.x2 = Math.max(Math.min(moveStart.cropper.x2 + moveX, cropperPosition.x1 + settings.cropperScaledMaxWidth),
           cropperPosition.x1 + settings.cropperScaledMinWidth);
         break;
       case 'bottomright':
-        cropperPosition.x2 = Math.max(Math.min(moveStart.x2 + moveX, cropperPosition.x1 + settings.cropperScaledMaxWidth),
+        cropperPosition.x2 = Math.max(Math.min(moveStart.cropper.x2 + moveX, cropperPosition.x1 + settings.cropperScaledMaxWidth),
           cropperPosition.x1 + settings.cropperScaledMinWidth);
-        cropperPosition.y2 = Math.max(Math.min(moveStart.y2 + moveY, cropperPosition.y1 + settings.cropperScaledMaxHeight),
+        cropperPosition.y2 = Math.max(Math.min(moveStart.cropper.y2 + moveY, cropperPosition.y1 + settings.cropperScaledMaxHeight),
           cropperPosition.y1 + settings.cropperScaledMinHeight);
         break;
       case 'bottom':
-        cropperPosition.y2 = Math.max(Math.min(moveStart.y2 + moveY, cropperPosition.y1 + settings.cropperScaledMaxHeight),
+        cropperPosition.y2 = Math.max(Math.min(moveStart.cropper.y2 + moveY, cropperPosition.y1 + settings.cropperScaledMaxHeight),
           cropperPosition.y1 + settings.cropperScaledMinHeight);
         break;
       case 'bottomleft':
-        cropperPosition.x1 = Math.min(Math.max(moveStart.x1 + moveX, cropperPosition.x2 - settings.cropperScaledMaxWidth),
+        cropperPosition.x1 = Math.min(Math.max(moveStart.cropper.x1 + moveX, cropperPosition.x2 - settings.cropperScaledMaxWidth),
           cropperPosition.x2 - settings.cropperScaledMinWidth);
-        cropperPosition.y2 = Math.max(Math.min(moveStart.y2 + moveY, cropperPosition.y1 + settings.cropperScaledMaxHeight),
+        cropperPosition.y2 = Math.max(Math.min(moveStart.cropper.y2 + moveY, cropperPosition.y1 + settings.cropperScaledMaxHeight),
           cropperPosition.y1 + settings.cropperScaledMinHeight);
         break;
       case 'center':
         const scale = event.scale;
         const newWidth = Math.min(
-          Math.max(settings.cropperScaledMinWidth, (Math.abs(moveStart.x2 - moveStart.x1)) * scale),
+          Math.max(settings.cropperScaledMinWidth, (Math.abs(moveStart.cropper.x2 - moveStart.cropper.x1)) * scale),
           settings.cropperScaledMaxWidth);
         const newHeight = Math.min(
-          Math.max(settings.cropperScaledMinHeight, (Math.abs(moveStart.y2 - moveStart.y1)) * scale),
+          Math.max(settings.cropperScaledMinHeight, (Math.abs(moveStart.cropper.y2 - moveStart.cropper.y1)) * scale),
           settings.cropperScaledMaxHeight);
         cropperPosition.x1 = moveStart.clientX - newWidth / 2;
         cropperPosition.x2 = moveStart.clientX + newWidth / 2;
@@ -217,4 +217,14 @@ export class CropperPositionService {
   getClientY(event: any): number {
     return event.touches?.[0].clientY || event.clientY || 0;
   }
+
+  isNewPosition(oldCropper: CropperPosition, newCropper: CropperPosition){
+    // TODO:(loiddy) Sometimes there's a difference in the 14th decimal place in the cropper position when a limit has been reached and accidentally you try to pinch over it. This should not trigger crop so toFixed prevents it. Check toFixed is still needed after changing resize in cropper pos service (in one of the next PRs).
+    if(oldCropper.x1.toFixed(3) !== newCropper.x1.toFixed(3)) return true;
+    if(oldCropper.y1.toFixed(3) !== newCropper.y1.toFixed(3)) return true;
+    if(oldCropper.x2.toFixed(3) !== newCropper.x2.toFixed(3)) return true;
+    if(oldCropper.y2.toFixed(3) !== newCropper.y2.toFixed(3)) return true;
+    return false;
+  }
 }
+

--- a/projects/ngx-image-cropper/src/lib/services/cropper-position.service.ts
+++ b/projects/ngx-image-cropper/src/lib/services/cropper-position.service.ts
@@ -5,28 +5,7 @@ import { CropperSettings } from '../interfaces/cropper.settings';
 @Injectable({ providedIn: 'root' })
 export class CropperPositionService {
 
-  /*
-  Up until now whenever resetCropperPosition was called, the cropper was reset to it's biggest possible size. 
-    
-  This is no longer the case, hence the new name.  
-
-  By the end of this PR, when there are changes to cropper min, max and/or static size (I'm calling this cropper size bounds) and mantainAspectRatio is FALSE, we only want to check the cropper is whithin its size bounds. If it is, return the same cropper position and size. And if it isn't, change cropper size but keep the position untouched – we then check it's within maxSize later in the code path in case any of it ended up outside during the resizing.
-    
-  This behaviour is completely new, and is needed at this stage – before the app wasn't responding to these changes and now it will so it needs a response. All the other ways in which this method was being used I've kept the same by adding the resetCropper parameter. Now it's always true, but when responding to changes in cropper bounding sizes, resetCropper will be false.
-    
-  In future PRs I'll be changing this so developers can pick when to reset the cropper as big as possible and when to work with the cropper that is already there. This will be done by using the resetCropper param or assigning 0 to cropperPosition.x2.
-
-  So far I've managed to have an app input called resetCropperToBiggestPossibleSize:boolean and I toggle it between interactions I send from the parent and the imageCropped event. But this doesn't work if auto crop is false, hence the cropperPosition.x2 === 0 check.
-
-  cropperPosition.x2 will only be 0 when the app is initialised – I've changed this too – or when a new source image is loaded – also changed. So it's safe to use it in this way too. I've also argued to myself that it's easy for developers to understand that if the cropper has no width, we're asking for a new one, as no width is no cropper and the app needs one to work. Fingers crossed.
-
-  Also, if you do some crazy testing by setting strange min and max values. You might find problems. That is also in a future PR.
-  */
   checkWithinCropperSizeBounds(cropperPosition: CropperPosition, settings: CropperSettings, maxSize: Dimensions, resetCropper: boolean): void {
-
-    // by the end of the PR we don't need a blocker here
-
-    console.log('CHECK CROPPER WITHIN CROPPER SIZE BOUNDS')
 
     if (resetCropper || cropperPosition.x2 === 0) {
       cropperPosition.x1 = 0;
@@ -40,7 +19,6 @@ export class CropperPositionService {
     const centerX = cropperPosition.x1 + cropperWidth / 2;
     const centerY = cropperPosition.y1 + cropperHeight / 2;
 
-    // added checking for min scaled size too
     if (settings.cropperStaticHeight && settings.cropperStaticWidth) {
       cropperWidth = maxSize.width > settings.cropperStaticWidth ? 
         settings.cropperStaticWidth : maxSize.width;
@@ -64,7 +42,6 @@ export class CropperPositionService {
   
 
   move(event: any, moveStart: MoveStart, cropperPosition: CropperPosition) {
-    console.log('MOVE')
     const diffX = this.getClientX(event) - moveStart.clientX;
     const diffY = this.getClientY(event) - moveStart.clientY;
 
@@ -75,7 +52,6 @@ export class CropperPositionService {
   }
 
   resize(event: any, moveStart: MoveStart, cropperPosition: CropperPosition, maxSize: Dimensions, settings: CropperSettings): void {
-    console.log('RESIZE')
     const moveX = this.getClientX(event) - moveStart.clientX;
     const moveY = this.getClientY(event) - moveStart.clientY;
     switch (moveStart.position) {
@@ -154,7 +130,6 @@ export class CropperPositionService {
   }
 
   checkAspectRatio(position: string, cropperPosition: CropperPosition, maxSize: Dimensions, settings: CropperSettings): void {
-    console.log(' - CHECK ASPECT RATIO')
     let overflowX = 0;
     let overflowY = 0;
 


### PR DESCRIPTION
Hi, it's me again. Sorry it took me a long time to get back to you and thank you for your patience. To recap, I’m slowly sending you changes to prepare for the image position service.

# How to reproduce the issues

I’ve prepped the app and demo for testing. It’s in the first commit so you can run the app at that point and at the end before cleanup and compare. Make sure to read the console too.

# Issues this PR fixes

When interacting with the app via a a pointer (mouse, touch, pinch, key) event and nothing has changed, crop is triggered (#571). It shouldn’t.

After a pointer event some unnecessary events are triggered again.

* Try moving the img, resizing and moving, and see repeated methods in console.

The app doesn’t respond to all input changes that affect how the app is displayed/functions at runtime. It should account for changes in all inputs. Developers can then choose how much they let their users do.

The app can sometimes duplicate operations. In one case it triplicates them.
The app should be able to respond to however many input changes are sent at the same time and only call the needed operations once.

* Press the Random Test button to test this. Crop is called three times. Pressing reset at this point also calls three crops. Other methods are also duplicated.

# Approach taken

Add a isNewPosition method and only doAutoCrop if it is a new position after pointer events. isNewPosition checks for differences in cropper and transform.translate before and after using moveStart and global variables. Fixes the first issue.

For the rest, change the flow of the app in how it responds to changes so operations are not repeated. 

### Considering that…

Changes that affect how the app is displayed can be divided by the steps they trigger. They are steps that… :

1. change the source of an image.
2. create a new image from a given source and render it.
3. change rules on how the cropper can be rendered.
4. change how the cropper is rendered.
5. change how the image is rendered.

They need to happen in this order, as each step will not be completed properly without the ones before it having been completed at least once at some point. 

* Right now there isn’t much of a relationship between 4 and 5 but there will be later on when image position service is added.

### The new approach is…

ngOnChanges checks for changes that lead to the steps and creates three clear paths to avoid repeating operations:

1. change the source of an image.
      ->  return if change in 1 (no loaded img) – end of path one.
3. create a new image from a given source and render it.
      ->  return if change in 2 – end of path two.
5. change rules on how the cropper can be rendered.
6. change how the cropper is rendered.
7. change how the image is rendered.
      ->  end of path three

A change in 1 and 2 eventually call steps 3-5 in checkImageMaxSizeRecursively. So if we separate them, no repeating opeartions. 

The first two code paths definitely lead to doAutoCrop. 

The third however, might not. Similarly to pointer events, create blockers using cropperPositionService.isNewPosition – only checks cropper – and isNewTransform  – checks all of transform.

To prevent pointer events triggering steps in ngOnChanges, I added blockers wherever changes in cropper and transform are being dealt with in ngOnChanges. They are the only values pointer events update. I compare previous and current state and block if the same.

Angular's previousValue can’t be used for this, as it’s a reference to before the pointer event and it needs to reference the state at the end of the pointer event. I reset their settings’ values in doAutoCrop and saved that at the beginning of ngOnChanges to solve this. 
* There’s a commented out console log where you can test this. 

# More things you should know

I plan to tweak how scaled min and max are set in another PR, so haven’t changed any of that here. 

I tried my best not to add anything that will mean developers have to change the way they’re implementing the app, or any big behaviour changes. These will happen in the next PRs :D

I’ve left some TODOs but I’m happy to delete them. I wrote  these and comments to explain possibly weird looking code. 

There’s one TODO for you to answer.

I haven’t forgotten to change maxSize to either of the options we talked about. I’m leaving that for when we get to the image position service.