### PR TITLE
Fix #620: remove problematic base64 encoded images

### DIFF
--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.ts
@@ -209,9 +209,6 @@ export class ImageCropperComponent implements OnChanges, OnInit, OnDestroy {
   }
 
   private reset(): void {
-    this.safeImgDataUrl.set('data:image/png;base64,iVBORw0KGg'
-      + 'oAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAU'
-      + 'AAarVyFEAAAAASUVORK5CYII=');
     this.state.loadedImage = undefined;
     this.state.maxSize = undefined;
     this.imageVisible = false;

--- a/projects/ngx-image-cropper/src/lib/utils/exif.utils.ts
+++ b/projects/ngx-image-cropper/src/lib/utils/exif.utils.ts
@@ -4,7 +4,7 @@ import { ExifTransform } from '../interfaces/exif-transform.interface';
 // - EXIF Orientation: 6 (Rotated 90° CCW)
 // Source: https://github.com/blueimp/JavaScript-Load-Image
 const testAutoOrientationImageURL =
-  'data:image/jpeg;base64,/9j/4QAiRXhpZgAATU0AKgAAAAgAAQESAAMAAAABAAYAAAA' +
+  '/9j/4QAiRXhpZgAATU0AKgAAAAgAAQESAAMAAAABAAYAAAA' +
   'AAAD/2wCEAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBA' +
   'QEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE' +
   'BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/AABEIAAEAAgMBEQACEQEDEQH/x' +
@@ -19,8 +19,29 @@ export function supportsAutomaticRotation(): Promise<boolean> {
       const supported = img.width === 1 && img.height === 2;
       resolve(supported);
     };
-    img.src = testAutoOrientationImageURL;
+    const blob = b64toBlob(testAutoOrientationImageURL, 'image/jpeg');
+    img.src = URL.createObjectURL(blob);
   });
+}
+
+function b64toBlob(b64Data: string, contentType = '', sliceSize = 512) {
+  const byteCharacters = atob(b64Data);
+  const byteArrays = [];
+
+  for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+    const slice = byteCharacters.slice(offset, offset + sliceSize);
+
+    const byteNumbers = new Array(slice.length);
+    for (let i = 0; i < slice.length; i++) {
+      byteNumbers[i] = slice.charCodeAt(i);
+    }
+
+    const byteArray = new Uint8Array(byteNumbers);
+    byteArrays.push(byteArray);
+  }
+
+  const blob = new Blob(byteArrays, { type: contentType });
+  return blob;
 }
 
 export function getTransformationsFromExifData(exifRotationOrArrayBuffer: number | ArrayBufferLike): ExifTransform {

--- a/projects/ngx-image-cropper/src/lib/utils/exif.utils.ts
+++ b/projects/ngx-image-cropper/src/lib/utils/exif.utils.ts
@@ -3,13 +3,13 @@ import { ExifTransform } from '../interfaces/exif-transform.interface';
 // Black 2x1 JPEG, with the following meta information set:
 // - EXIF Orientation: 6 (Rotated 90° CCW)
 // Source: https://github.com/blueimp/JavaScript-Load-Image
-const testAutoOrientationImageURL =
+const testAutoOrientationImageURL = URL.createObjectURL(b64toBlob(
   '/9j/4QAiRXhpZgAATU0AKgAAAAgAAQESAAMAAAABAAYAAAA' +
   'AAAD/2wCEAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBA' +
   'QEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE' +
   'BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/AABEIAAEAAgMBEQACEQEDEQH/x' +
   'ABKAAEAAAAAAAAAAAAAAAAAAAALEAEAAAAAAAAAAAAAAAAAAAAAAQEAAAAAAAAAAAAAAAA' +
-  'AAAAAEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8H//2Q==';
+  'AAAAAEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8H//2Q=='));
 
 export function supportsAutomaticRotation(): Promise<boolean> {
   return new Promise((resolve) => {
@@ -19,8 +19,7 @@ export function supportsAutomaticRotation(): Promise<boolean> {
       const supported = img.width === 1 && img.height === 2;
       resolve(supported);
     };
-    const blob = b64toBlob(testAutoOrientationImageURL, 'image/jpeg');
-    img.src = URL.createObjectURL(blob);
+    img.src = testAutoOrientationImageURL;
   });
 }
 
@@ -40,8 +39,7 @@ function b64toBlob(b64Data: string, contentType = '', sliceSize = 512) {
     byteArrays.push(byteArray);
   }
 
-  const blob = new Blob(byteArrays, { type: contentType });
-  return blob;
+  return new Blob(byteArrays, { type: contentType });
 }
 
 export function getTransformationsFromExifData(exifRotationOrArrayBuffer: number | ArrayBufferLike): ExifTransform {


### PR DESCRIPTION
Hello,

This PR should fix issue #620 we submitted earlier this year and should make the image cropper more compatible with a stricter Content Security Policy. It removes all problematic hardcoded usages of base64/data: urls and replaces them with permitted alternatives.

If there are any questions, feel free to ask. Thank you for your time! 🙂