### PR TITLE
Explicitly set display of source image to `inline`

### DIFF
--- a/projects/ngx-image-cropper/src/lib/component/image-cropper.component.scss
+++ b/projects/ngx-image-cropper/src/lib/component/image-cropper.component.scss
@@ -13,6 +13,7 @@
     position: relative;
 
     img.ngx-ic-source-image {
+      display: inline;
       max-width: 100%;
       max-height: 100%;
       transform-origin: center;


### PR DESCRIPTION
The component relies on `text-align: center` to center the source image. This only works if the source image has the CSS property `display: inline`. Although this is the browser default, it is often overridden by CSS resets (notably `display: block` for responsive images), causing some misalignment of the cropper vs source image, as shown in #676.

See #676 