### PR TITLE
fix: Cannot run Jest tests that includes ngx-image-cropper

### DIFF
--- a/projects/ngx-image-cropper/src/lib/services/crop.service.ts
+++ b/projects/ngx-image-cropper/src/lib/services/crop.service.ts
@@ -67,7 +67,7 @@ export class CropService {
   private async cropToBlob(output: ImageCroppedEvent, cropCanvas: HTMLCanvasElement, input: CropInput): Promise<ImageCroppedEvent> {
     output.blob = await new Promise<Blob | null>(resolve => cropCanvas.toBlob(resolve, 'image/' + (input.options?.format ?? 'png'), this.getQuality(input.options)));
     if (output.blob) {
-      output.objectUrl = URL.createObjectURL(output.blob);
+      output.objectUrl = globalThis.URL.createObjectURL(output.blob);
     }
     return output;
   }

--- a/projects/ngx-image-cropper/src/lib/services/load-image.service.ts
+++ b/projects/ngx-image-cropper/src/lib/services/load-image.service.ts
@@ -59,7 +59,7 @@ export class LoadImageService {
     const res = await new Promise<LoadImageArrayBuffer>(async (resolve, reject) => {
       try {
         const blob = new Blob([arrayBuffer], imageType ? {type: imageType} : undefined);
-        const objectUrl = URL.createObjectURL(blob);
+        const objectUrl = globalThis.URL.createObjectURL(blob);
         const originalImage = new Image();
         const isSvg = imageType === 'image/svg+xml';
         const originalImageSize = isSvg ? await this.getSvgImageSize(blob) : undefined;
@@ -164,7 +164,7 @@ export class LoadImageService {
     if (!blob) {
       throw new Error('Failed to get Blob for transformed image.');
     }
-    const objectUrl = URL.createObjectURL(blob);
+    const objectUrl = globalThis.URL.createObjectURL(blob);
     const transformedImage = await this.loadImageFromObjectUrl(objectUrl);
     return {
       original: {

--- a/projects/ngx-image-cropper/src/lib/utils/exif.utils.ts
+++ b/projects/ngx-image-cropper/src/lib/utils/exif.utils.ts
@@ -4,7 +4,7 @@ import { ExifTransform } from '../interfaces/exif-transform.interface';
 // - EXIF Orientation: 6 (Rotated 90° CCW)
 // Source: https://github.com/blueimp/JavaScript-Load-Image
 const testAutoOrientationImageByteArray = [new Uint8Array([255, 216, 255, 225, 0, 34, 69, 120, 105, 102, 0, 0, 77, 77, 0, 42, 0, 0, 0, 8, 0, 1, 1, 18, 0, 3, 0, 0, 0, 1, 0, 6, 0, 0, 0, 0, 0, 0, 255, 219, 0, 132, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 255, 192, 0, 17, 8, 0, 1, 0, 2, 3, 1, 17, 0, 2, 17, 1, 3, 17, 1, 255, 196, 0, 74, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 16, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 218, 0, 12, 3, 1, 0, 2, 17, 3, 17, 0, 63, 0, 63, 240, 127, 255, 217])];
-const testAutoOrientationImageURL = URL.createObjectURL(new Blob(testAutoOrientationImageByteArray, {type: 'image/jpeg'}));
+const testAutoOrientationImageURL = globalThis.URL.createObjectURL(new Blob(testAutoOrientationImageByteArray, {type: 'image/jpeg'}));
 
 export function supportsAutomaticRotation(): Promise<boolean> {
   return new Promise((resolve) => {


### PR DESCRIPTION
Running Jest tests when using ngx-image-croppper causes the error `TypeError: URL.createObjectURL is not a function`.

To ensure one can reliably mock `URL` in a Nodejs environment (like Jest) we prefix `URL` with `globalThis` so that one can mock this in tests like so `globalThis.URL.createObjectURL = jest.fn()`.